### PR TITLE
adminer removed an minor optimization

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,4 +1,4 @@
-name: Test docker project setup
+name: Project setup
 
 on: [push]
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
+[![Actions Status](https://github.com/Klizzy/shopware6-development/workflows/Project%20setup/badge.svg)](https://github.com/Klizzy/shopware6-development/actions)
+
 # Shopware 6 development template
 
 This repository is a template for local development and enables you to create a running Shopware 6 instance.
 Use this setup for developing directly on Shopware 6 or for developing plugins for Shopware 6.
 
 The installation guide, together with the complete documentation, is available at [docs.shopware.com](https://docs.shopware.com/en/shopware-platform-dev-en/getting-started).
-
-# Installation
 
 # Installation
 

--- a/dev-ops/docker/docker-compose.override.yml
+++ b/dev-ops/docker/docker-compose.override.yml
@@ -31,10 +31,6 @@ services:
     ports:
       - "4406:3306"
 
-  adminer:
-    ports:
-      - "8001:8080"
-
   mailhog:
     ports:
       - "8002:8025"

--- a/dev-ops/docker/scripts/fix_permissions.sh
+++ b/dev-ops/docker/scripts/fix_permissions.sh
@@ -2,9 +2,5 @@
 
 APP_CONTAINER=$(docker-compose ps -q app_server)
 
-docker exec -i ${APP_CONTAINER} /bin/sh -c 'chown -Rf application:application /app'
-docker exec -i ${APP_CONTAINER} /bin/sh -c 'chmod -R 0777 /app'
-docker exec -i ${APP_CONTAINER} /bin/sh -c 'chown -Rf application:application /.npm'
-docker exec -i ${APP_CONTAINER} /bin/sh -c 'chmod -R 0777 /.npm'
-docker exec -i ${APP_CONTAINER} /bin/sh -c 'chown -Rf application:application /.composer'
-docker exec -i ${APP_CONTAINER} /bin/sh -c 'chmod -R 0777 /.composer'
+docker exec -i ${APP_CONTAINER} /bin/sh -c 'chown -Rf application:application /app /.npm /.composer'
+docker exec -i ${APP_CONTAINER} /bin/sh -c 'chmod -R 0777 /app /.npm /.composer'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,11 +31,6 @@ services:
   mailhog:
     image: mailhog/mailhog
 
-  adminer:
-    image: adminer:latest
-    links:
-      - app_mysql:mysql
-
   elasticsearch:
     image: elastic/elasticsearch:7.1.1
     environment:


### PR DESCRIPTION
I removed admirer, because we usually don't need it and it collided with the open port for the `administration:watch` port. This only occurs if you want start the file watcher for the administration
