### PR TITLE
Minor omtimization

### DIFF
--- a/dev-ops/docker/docker-compose.override.yml
+++ b/dev-ops/docker/docker-compose.override.yml
@@ -31,10 +31,6 @@ services:
     ports:
       - "4406:3306"
 
-  adminer:
-    ports:
-      - "8001:8080"
-
   mailhog:
     ports:
       - "8002:8025"

--- a/dev-ops/docker/scripts/fix_permissions.sh
+++ b/dev-ops/docker/scripts/fix_permissions.sh
@@ -2,9 +2,5 @@
 
 APP_CONTAINER=$(docker-compose ps -q app_server)
 
-docker exec -i ${APP_CONTAINER} /bin/sh -c 'chown -Rf application:application /app'
-docker exec -i ${APP_CONTAINER} /bin/sh -c 'chmod -R 0777 /app'
-docker exec -i ${APP_CONTAINER} /bin/sh -c 'chown -Rf application:application /.npm'
-docker exec -i ${APP_CONTAINER} /bin/sh -c 'chmod -R 0777 /.npm'
-docker exec -i ${APP_CONTAINER} /bin/sh -c 'chown -Rf application:application /.composer'
-docker exec -i ${APP_CONTAINER} /bin/sh -c 'chmod -R 0777 /.composer'
+docker exec -i ${APP_CONTAINER} /bin/sh -c 'chown -Rf application:application /app /.npm /.composer'
+docker exec -i ${APP_CONTAINER} /bin/sh -c 'chmod -R 0777 /app /.npm /.composer'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,11 +31,6 @@ services:
   mailhog:
     image: mailhog/mailhog
 
-  adminer:
-    image: adminer:latest
-    links:
-      - app_mysql:mysql
-
   elasticsearch:
     image: elastic/elasticsearch:7.1.1
     environment:


### PR DESCRIPTION
I removed admirer, because we usually don't need it and it collided with the open port for the administration:watch port. This only occurs if you want start the file watcher for the administration